### PR TITLE
Show updated team after driver switches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formulaone-card",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "description": "Frontend card for Home Assistant to display Formula One data",
   "main": "index.js",
   "scripts": {

--- a/src/cards/driver-standings.ts
+++ b/src/cards/driver-standings.ts
@@ -28,7 +28,7 @@ export default class DriverStandings extends BaseCard {
                 <td class="width-40 text-center">${standing.position}</td>
                 <td>${(this.config.standings?.show_flag ? html`<img height="10" width="20" src="${getCountryFlagByNationality(this, standing.Driver.nationality)}">&nbsp;` : '')}${standing.Driver.code}</td>
                 <td>${getDriverName(standing.Driver, this.config)}</td>
-                ${(this.config.standings?.show_team ? html`${renderConstructorColumn(this, standing.Constructors[0])}` : '')}
+                ${(this.config.standings?.show_team ? html`${renderConstructorColumn(this, standing.Constructors[standing.Constructors.length - 1])}` : '')}
                 <td class="width-60 text-center">${standing.points}</td>
                 <td class="text-center">${standing.wins}</td>
             </tr>`;


### PR DESCRIPTION
This change grabs the last team from the constructor list, so it reflects the most recent one after any transitions.

Example:
In 2025, Lawson and Tsunoda switched teams, but the card still showed their first team of the season. With this fix, it now shows the correct, updated team.