### PR TITLE
Replace deprecated restcountries.com v2 API with static data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formulaone-card",
-  "version": "1.14.6", 
+  "version": "1.14.7", 
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "formulaone-card",
-      "version": "1.14.6",
+      "version": "1.14.7",
       "license": "ISC",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.22.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formulaone-card",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "description": "Frontend card for Home Assistant to display Formula One data",
   "main": "index.js",
   "scripts": {

--- a/src/api/restcountry-client.ts
+++ b/src/api/restcountry-client.ts
@@ -1,23 +1,13 @@
-import { LocalStorageItem } from "../types/formulaone-card-types";
 import { Country } from "../types/rest-country-types";
-import { ClientBase } from "./client-base";
+import { countries } from "../data/countries";
 
-export default class RestCountryClient extends ClientBase {
-    
-    baseUrl = 'https://restcountries.com/v2';
-    allEndpoint = 'all?fields=name,flag,flags,nativeName,demonym,population,altSpellings';
+export default class RestCountryClient {
 
-    async GetAll() : Promise<Country[]> {   
-        return await this.GetData<Country[]>(this.allEndpoint, true, 730);
+    GetAll() : Country[] {
+        return countries;
     }
-    
-    GetCountriesFromLocalStorage() : Country[] {
-        const localStorageData = localStorage.getItem(this.allEndpoint);
 
-        if(localStorageData) {
-            const item: LocalStorageItem = <LocalStorageItem>JSON.parse(localStorageData);
-            return <Country[]>JSON.parse(item.data);
-        }
-        return [];
+    GetCountriesFromLocalStorage() : Country[] {
+        return countries;
     }
 }

--- a/src/data/countries.ts
+++ b/src/data/countries.ts
@@ -1,0 +1,3765 @@
+import { Country } from "../types/rest-country-types";
+
+// Static country data — replaces deprecated restcountries.com v2 API
+// Only includes fields used by the card: name, nativeName, demonym, population, altSpellings, flags
+export const countries: Country[] = [
+  {
+    "name": "Afghanistan",
+    "nativeName": "افغانستان",
+    "demonym": "Afghan",
+    "population": 40218234,
+    "altSpellings": [
+      "AF",
+      "Afġānistān"
+    ],
+    "flags": {
+      "svg": "https://upload.wikimedia.org/wikipedia/commons/5/5c/Flag_of_the_Taliban.svg",
+      "png": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Flag_of_the_Taliban.svg/320px-Flag_of_the_Taliban.svg.png"
+    }
+  },
+  {
+    "name": "Åland Islands",
+    "nativeName": "Åland",
+    "demonym": "Ålandish",
+    "population": 28875,
+    "altSpellings": [
+      "AX",
+      "Aaland",
+      "Aland",
+      "Ahvenanmaa"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ax.svg",
+      "png": "https://flagcdn.com/w320/ax.png"
+    }
+  },
+  {
+    "name": "Albania",
+    "nativeName": "Shqipëria",
+    "demonym": "Albanian",
+    "population": 2837743,
+    "altSpellings": [
+      "AL",
+      "Shqipëri",
+      "Shqipëria",
+      "Shqipnia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/al.svg",
+      "png": "https://flagcdn.com/w320/al.png"
+    }
+  },
+  {
+    "name": "Algeria",
+    "nativeName": "الجزائر",
+    "demonym": "Algerian",
+    "population": 44700000,
+    "altSpellings": [
+      "DZ",
+      "Dzayer",
+      "Algérie"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/dz.svg",
+      "png": "https://flagcdn.com/w320/dz.png"
+    }
+  },
+  {
+    "name": "American Samoa",
+    "nativeName": "American Samoa",
+    "demonym": "American Samoan",
+    "population": 55197,
+    "altSpellings": [
+      "AS",
+      "Amerika Sāmoa",
+      "Amelika Sāmoa",
+      "Sāmoa Amelika"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/as.svg",
+      "png": "https://flagcdn.com/w320/as.png"
+    }
+  },
+  {
+    "name": "Andorra",
+    "nativeName": "Andorra",
+    "demonym": "Andorran",
+    "population": 77265,
+    "altSpellings": [
+      "AD",
+      "Principality of Andorra",
+      "Principat d'Andorra"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ad.svg",
+      "png": "https://flagcdn.com/w320/ad.png"
+    }
+  },
+  {
+    "name": "Angola",
+    "nativeName": "Angola",
+    "demonym": "Angolan",
+    "population": 32866268,
+    "altSpellings": [
+      "AO",
+      "República de Angola",
+      "ʁɛpublika de an'ɡɔla"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ao.svg",
+      "png": "https://flagcdn.com/w320/ao.png"
+    }
+  },
+  {
+    "name": "Anguilla",
+    "nativeName": "Anguilla",
+    "demonym": "Anguillian",
+    "population": 13452,
+    "altSpellings": [
+      "AI"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ai.svg",
+      "png": "https://flagcdn.com/w320/ai.png"
+    }
+  },
+  {
+    "name": "Antarctica",
+    "nativeName": "Antarctica",
+    "demonym": "Antarctic",
+    "population": 1000,
+    "altSpellings": [],
+    "flags": {
+      "svg": "https://flagcdn.com/aq.svg",
+      "png": "https://flagcdn.com/w320/aq.png"
+    }
+  },
+  {
+    "name": "Antigua and Barbuda",
+    "nativeName": "Antigua and Barbuda",
+    "demonym": "Antiguan, Barbudan",
+    "population": 97928,
+    "altSpellings": [
+      "AG"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ag.svg",
+      "png": "https://flagcdn.com/w320/ag.png"
+    }
+  },
+  {
+    "name": "Argentina",
+    "nativeName": "Argentina",
+    "demonym": "Argentinean",
+    "population": 45376763,
+    "altSpellings": [
+      "AR",
+      "Argentine Republic",
+      "República Argentina"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ar.svg",
+      "png": "https://flagcdn.com/w320/ar.png"
+    }
+  },
+  {
+    "name": "Armenia",
+    "nativeName": "Հայաստան",
+    "demonym": "Armenian",
+    "population": 2963234,
+    "altSpellings": [
+      "AM",
+      "Hayastan",
+      "Republic of Armenia",
+      "Հայաստանի Հանրապետություն"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/am.svg",
+      "png": "https://flagcdn.com/w320/am.png"
+    }
+  },
+  {
+    "name": "Aruba",
+    "nativeName": "Aruba",
+    "demonym": "Aruban",
+    "population": 106766,
+    "altSpellings": [
+      "AW"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/aw.svg",
+      "png": "https://flagcdn.com/w320/aw.png"
+    }
+  },
+  {
+    "name": "Australia",
+    "nativeName": "Australia",
+    "demonym": "Australian",
+    "population": 25687041,
+    "altSpellings": [
+      "AU"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/au.svg",
+      "png": "https://flagcdn.com/w320/au.png"
+    }
+  },
+  {
+    "name": "Austria",
+    "nativeName": "Österreich",
+    "demonym": "Austrian",
+    "population": 8917205,
+    "altSpellings": [
+      "AT",
+      "Österreich",
+      "Osterreich",
+      "Oesterreich"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/at.svg",
+      "png": "https://flagcdn.com/w320/at.png"
+    }
+  },
+  {
+    "name": "Azerbaijan",
+    "nativeName": "Azərbaycan",
+    "demonym": "Azerbaijani",
+    "population": 10110116,
+    "altSpellings": [
+      "AZ",
+      "Republic of Azerbaijan",
+      "Azərbaycan Respublikası"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/az.svg",
+      "png": "https://flagcdn.com/w320/az.png"
+    }
+  },
+  {
+    "name": "Bahamas",
+    "nativeName": "Bahamas",
+    "demonym": "Bahamian",
+    "population": 393248,
+    "altSpellings": [
+      "BS",
+      "Commonwealth of the Bahamas"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bs.svg",
+      "png": "https://flagcdn.com/w320/bs.png"
+    }
+  },
+  {
+    "name": "Bahrain",
+    "nativeName": "‏البحرين",
+    "demonym": "Bahraini",
+    "population": 1701583,
+    "altSpellings": [
+      "BH",
+      "Kingdom of Bahrain",
+      "Mamlakat al-Baḥrayn"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bh.svg",
+      "png": "https://flagcdn.com/w320/bh.png"
+    }
+  },
+  {
+    "name": "Bangladesh",
+    "nativeName": "Bangladesh",
+    "demonym": "Bangladeshi",
+    "population": 164689383,
+    "altSpellings": [
+      "BD",
+      "People's Republic of Bangladesh",
+      "Gônôprôjatôntri Bangladesh"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bd.svg",
+      "png": "https://flagcdn.com/w320/bd.png"
+    }
+  },
+  {
+    "name": "Barbados",
+    "nativeName": "Barbados",
+    "demonym": "Barbadian",
+    "population": 287371,
+    "altSpellings": [
+      "BB"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bb.svg",
+      "png": "https://flagcdn.com/w320/bb.png"
+    }
+  },
+  {
+    "name": "Belarus",
+    "nativeName": "Белару́сь",
+    "demonym": "Belarusian",
+    "population": 9398861,
+    "altSpellings": [
+      "BY",
+      "Bielaruś",
+      "Republic of Belarus",
+      "Белоруссия",
+      "Республика Беларусь",
+      "Belorussiya",
+      "Respublika Belarus’"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/by.svg",
+      "png": "https://flagcdn.com/w320/by.png"
+    }
+  },
+  {
+    "name": "Belgium",
+    "nativeName": "België",
+    "demonym": "Belgian",
+    "population": 11555997,
+    "altSpellings": [
+      "BE",
+      "België",
+      "Belgie",
+      "Belgien",
+      "Belgique",
+      "Kingdom of Belgium",
+      "Koninkrijk België",
+      "Royaume de Belgique",
+      "Königreich Belgien"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/be.svg",
+      "png": "https://flagcdn.com/w320/be.png"
+    }
+  },
+  {
+    "name": "Belize",
+    "nativeName": "Belize",
+    "demonym": "Belizean",
+    "population": 397621,
+    "altSpellings": [
+      "BZ"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bz.svg",
+      "png": "https://flagcdn.com/w320/bz.png"
+    }
+  },
+  {
+    "name": "Benin",
+    "nativeName": "Bénin",
+    "demonym": "Beninese",
+    "population": 12123198,
+    "altSpellings": [
+      "BJ",
+      "Republic of Benin",
+      "République du Bénin"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bj.svg",
+      "png": "https://flagcdn.com/w320/bj.png"
+    }
+  },
+  {
+    "name": "Bermuda",
+    "nativeName": "Bermuda",
+    "demonym": "Bermudian",
+    "population": 63903,
+    "altSpellings": [
+      "BM",
+      "The Islands of Bermuda",
+      "The Bermudas",
+      "Somers Isles"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bm.svg",
+      "png": "https://flagcdn.com/w320/bm.png"
+    }
+  },
+  {
+    "name": "Bhutan",
+    "nativeName": "ʼbrug-yul",
+    "demonym": "Bhutanese",
+    "population": 771612,
+    "altSpellings": [
+      "BT",
+      "Kingdom of Bhutan"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bt.svg",
+      "png": "https://flagcdn.com/w320/bt.png"
+    }
+  },
+  {
+    "name": "Bolivia (Plurinational State of)",
+    "nativeName": "Bolivia",
+    "demonym": "Bolivian",
+    "population": 11673029,
+    "altSpellings": [
+      "BO",
+      "Buliwya",
+      "Wuliwya",
+      "Plurinational State of Bolivia",
+      "Estado Plurinacional de Bolivia",
+      "Buliwya Mamallaqta",
+      "Wuliwya Suyu",
+      "Tetã Volívia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bo.svg",
+      "png": "https://flagcdn.com/w320/bo.png"
+    }
+  },
+  {
+    "name": "Bonaire, Sint Eustatius and Saba",
+    "nativeName": "Bonaire",
+    "demonym": "Dutch",
+    "population": 17408,
+    "altSpellings": [
+      "BQ",
+      "Boneiru"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bq.svg",
+      "png": "https://flagcdn.com/w320/bq.png"
+    }
+  },
+  {
+    "name": "Bosnia and Herzegovina",
+    "nativeName": "Bosna i Hercegovina",
+    "demonym": "Bosnian, Herzegovinian",
+    "population": 3280815,
+    "altSpellings": [
+      "BA",
+      "Bosnia-Herzegovina",
+      "Босна и Херцеговина"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ba.svg",
+      "png": "https://flagcdn.com/w320/ba.png"
+    }
+  },
+  {
+    "name": "Botswana",
+    "nativeName": "Botswana",
+    "demonym": "Motswana",
+    "population": 2351625,
+    "altSpellings": [
+      "BW",
+      "Republic of Botswana",
+      "Lefatshe la Botswana"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bw.svg",
+      "png": "https://flagcdn.com/w320/bw.png"
+    }
+  },
+  {
+    "name": "Bouvet Island",
+    "nativeName": "Bouvetøya",
+    "demonym": "Norwegian",
+    "population": 0,
+    "altSpellings": [
+      "BV",
+      "Bouvetøya",
+      "Bouvet-øya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bv.svg",
+      "png": "https://flagcdn.com/w320/bv.png"
+    }
+  },
+  {
+    "name": "Brazil",
+    "nativeName": "Brasil",
+    "demonym": "Brazilian",
+    "population": 212559409,
+    "altSpellings": [
+      "BR",
+      "Brasil",
+      "Federative Republic of Brazil",
+      "República Federativa do Brasil"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/br.svg",
+      "png": "https://flagcdn.com/w320/br.png"
+    }
+  },
+  {
+    "name": "British Indian Ocean Territory",
+    "nativeName": "British Indian Ocean Territory",
+    "demonym": "Indian",
+    "population": 3000,
+    "altSpellings": [
+      "IO"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/io.svg",
+      "png": "https://flagcdn.com/w320/io.png"
+    }
+  },
+  {
+    "name": "United States Minor Outlying Islands",
+    "nativeName": "United States Minor Outlying Islands",
+    "demonym": "American",
+    "population": 300,
+    "altSpellings": [
+      "UM"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/um.svg",
+      "png": "https://flagcdn.com/w320/um.png"
+    }
+  },
+  {
+    "name": "Virgin Islands (British)",
+    "nativeName": "British Virgin Islands",
+    "demonym": "Virgin Islander",
+    "population": 30237,
+    "altSpellings": [
+      "VG"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/vg.svg",
+      "png": "https://flagcdn.com/w320/vg.png"
+    }
+  },
+  {
+    "name": "Virgin Islands (U.S.)",
+    "nativeName": "Virgin Islands of the United States",
+    "demonym": "Virgin Islander",
+    "population": 106290,
+    "altSpellings": [
+      "VI",
+      "USVI",
+      "American Virgin Islands",
+      "U.S. Virgin Islands"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/vi.svg",
+      "png": "https://flagcdn.com/w320/vi.png"
+    }
+  },
+  {
+    "name": "Brunei Darussalam",
+    "nativeName": "Negara Brunei Darussalam",
+    "demonym": "Bruneian",
+    "population": 437483,
+    "altSpellings": [
+      "BN",
+      "Nation of Brunei",
+      " the Abode of Peace"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bn.svg",
+      "png": "https://flagcdn.com/w320/bn.png"
+    }
+  },
+  {
+    "name": "Bulgaria",
+    "nativeName": "България",
+    "demonym": "Bulgarian",
+    "population": 6927288,
+    "altSpellings": [
+      "BG",
+      "Republic of Bulgaria",
+      "Република България"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bg.svg",
+      "png": "https://flagcdn.com/w320/bg.png"
+    }
+  },
+  {
+    "name": "Burkina Faso",
+    "nativeName": "Burkina Faso",
+    "demonym": "Burkinabe",
+    "population": 20903278,
+    "altSpellings": [
+      "BF"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bf.svg",
+      "png": "https://flagcdn.com/w320/bf.png"
+    }
+  },
+  {
+    "name": "Burundi",
+    "nativeName": "Burundi",
+    "demonym": "Burundian",
+    "population": 11890781,
+    "altSpellings": [
+      "BI",
+      "Republic of Burundi",
+      "Republika y'Uburundi",
+      "République du Burundi"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bi.svg",
+      "png": "https://flagcdn.com/w320/bi.png"
+    }
+  },
+  {
+    "name": "Cambodia",
+    "nativeName": "Kâmpŭchéa",
+    "demonym": "Cambodian",
+    "population": 16718971,
+    "altSpellings": [
+      "KH",
+      "Kingdom of Cambodia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kh.svg",
+      "png": "https://flagcdn.com/w320/kh.png"
+    }
+  },
+  {
+    "name": "Cameroon",
+    "nativeName": "Cameroon",
+    "demonym": "Cameroonian",
+    "population": 26545864,
+    "altSpellings": [
+      "CM",
+      "Republic of Cameroon",
+      "République du Cameroun"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cm.svg",
+      "png": "https://flagcdn.com/w320/cm.png"
+    }
+  },
+  {
+    "name": "Canada",
+    "nativeName": "Canada",
+    "demonym": "Canadian",
+    "population": 38005238,
+    "altSpellings": [
+      "CA"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ca.svg",
+      "png": "https://flagcdn.com/w320/ca.png"
+    }
+  },
+  {
+    "name": "Cabo Verde",
+    "nativeName": "Cabo Verde",
+    "demonym": "Cape Verdian",
+    "population": 555988,
+    "altSpellings": [
+      "CV",
+      "Republic of Cabo Verde",
+      "República de Cabo Verde"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cv.svg",
+      "png": "https://flagcdn.com/w320/cv.png"
+    }
+  },
+  {
+    "name": "Cayman Islands",
+    "nativeName": "Cayman Islands",
+    "demonym": "Caymanian",
+    "population": 65720,
+    "altSpellings": [
+      "KY"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ky.svg",
+      "png": "https://flagcdn.com/w320/ky.png"
+    }
+  },
+  {
+    "name": "Central African Republic",
+    "nativeName": "Ködörösêse tî Bêafrîka",
+    "demonym": "Central African",
+    "population": 4829764,
+    "altSpellings": [
+      "CF",
+      "Central African Republic",
+      "République centrafricaine"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cf.svg",
+      "png": "https://flagcdn.com/w320/cf.png"
+    }
+  },
+  {
+    "name": "Chad",
+    "nativeName": "Tchad",
+    "demonym": "Chadian",
+    "population": 16425859,
+    "altSpellings": [
+      "TD",
+      "Tchad",
+      "Republic of Chad",
+      "République du Tchad"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/td.svg",
+      "png": "https://flagcdn.com/w320/td.png"
+    }
+  },
+  {
+    "name": "Chile",
+    "nativeName": "Chile",
+    "demonym": "Chilean",
+    "population": 19116209,
+    "altSpellings": [
+      "CL",
+      "Republic of Chile",
+      "República de Chile"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cl.svg",
+      "png": "https://flagcdn.com/w320/cl.png"
+    }
+  },
+  {
+    "name": "China",
+    "nativeName": "中国",
+    "demonym": "Chinese",
+    "population": 1402112000,
+    "altSpellings": [
+      "CN",
+      "Zhōngguó",
+      "Zhongguo",
+      "Zhonghua",
+      "People's Republic of China",
+      "中华人民共和国",
+      "Zhōnghuá Rénmín Gònghéguó"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cn.svg",
+      "png": "https://flagcdn.com/w320/cn.png"
+    }
+  },
+  {
+    "name": "Christmas Island",
+    "nativeName": "Christmas Island",
+    "demonym": "Christmas Island",
+    "population": 2072,
+    "altSpellings": [
+      "CX",
+      "Territory of Christmas Island"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cx.svg",
+      "png": "https://flagcdn.com/w320/cx.png"
+    }
+  },
+  {
+    "name": "Cocos (Keeling) Islands",
+    "nativeName": "Cocos (Keeling) Islands",
+    "demonym": "Cocos Islander",
+    "population": 550,
+    "altSpellings": [
+      "CC",
+      "Territory of the Cocos (Keeling) Islands",
+      "Keeling Islands"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cc.svg",
+      "png": "https://flagcdn.com/w320/cc.png"
+    }
+  },
+  {
+    "name": "Colombia",
+    "nativeName": "Colombia",
+    "demonym": "Colombian",
+    "population": 50882884,
+    "altSpellings": [
+      "CO",
+      "Republic of Colombia",
+      "República de Colombia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/co.svg",
+      "png": "https://flagcdn.com/w320/co.png"
+    }
+  },
+  {
+    "name": "Comoros",
+    "nativeName": "Komori",
+    "demonym": "Comoran",
+    "population": 869595,
+    "altSpellings": [
+      "KM",
+      "Union of the Comoros",
+      "Union des Comores",
+      "Udzima wa Komori",
+      "al-Ittiḥād al-Qumurī"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/km.svg",
+      "png": "https://flagcdn.com/w320/km.png"
+    }
+  },
+  {
+    "name": "Congo",
+    "nativeName": "République du Congo",
+    "demonym": "Congolese",
+    "population": 5518092,
+    "altSpellings": [
+      "CG",
+      "Congo-Brazzaville"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cg.svg",
+      "png": "https://flagcdn.com/w320/cg.png"
+    }
+  },
+  {
+    "name": "Congo (Democratic Republic of the)",
+    "nativeName": "République démocratique du Congo",
+    "demonym": "Congolese",
+    "population": 89561404,
+    "altSpellings": [
+      "CD",
+      "DR Congo",
+      "Congo-Kinshasa",
+      "DRC"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cd.svg",
+      "png": "https://flagcdn.com/w320/cd.png"
+    }
+  },
+  {
+    "name": "Cook Islands",
+    "nativeName": "Cook Islands",
+    "demonym": "Cook Islander",
+    "population": 18100,
+    "altSpellings": [
+      "CK",
+      "Kūki 'Āirani"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ck.svg",
+      "png": "https://flagcdn.com/w320/ck.png"
+    }
+  },
+  {
+    "name": "Costa Rica",
+    "nativeName": "Costa Rica",
+    "demonym": "Costa Rican",
+    "population": 5094114,
+    "altSpellings": [
+      "CR",
+      "Republic of Costa Rica",
+      "República de Costa Rica"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cr.svg",
+      "png": "https://flagcdn.com/w320/cr.png"
+    }
+  },
+  {
+    "name": "Croatia",
+    "nativeName": "Hrvatska",
+    "demonym": "Croatian",
+    "population": 4047200,
+    "altSpellings": [
+      "HR",
+      "Hrvatska",
+      "Republic of Croatia",
+      "Republika Hrvatska"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/hr.svg",
+      "png": "https://flagcdn.com/w320/hr.png"
+    }
+  },
+  {
+    "name": "Cuba",
+    "nativeName": "Cuba",
+    "demonym": "Cuban",
+    "population": 11326616,
+    "altSpellings": [
+      "CU",
+      "Republic of Cuba",
+      "República de Cuba"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cu.svg",
+      "png": "https://flagcdn.com/w320/cu.png"
+    }
+  },
+  {
+    "name": "Curaçao",
+    "nativeName": "Curaçao",
+    "demonym": "Dutch",
+    "population": 155014,
+    "altSpellings": [
+      "CW",
+      "Curacao",
+      "Kòrsou",
+      "Country of Curaçao",
+      "Land Curaçao",
+      "Pais Kòrsou"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cw.svg",
+      "png": "https://flagcdn.com/w320/cw.png"
+    }
+  },
+  {
+    "name": "Cyprus",
+    "nativeName": "Κύπρος",
+    "demonym": "Cypriot",
+    "population": 1207361,
+    "altSpellings": [
+      "CY",
+      "Kýpros",
+      "Kıbrıs",
+      "Republic of Cyprus",
+      "Κυπριακή Δημοκρατία",
+      "Kıbrıs Cumhuriyeti"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cy.svg",
+      "png": "https://flagcdn.com/w320/cy.png"
+    }
+  },
+  {
+    "name": "Czech Republic",
+    "nativeName": "Česká republika",
+    "demonym": "Czech",
+    "population": 10698896,
+    "altSpellings": [
+      "CZ",
+      "Česká republika",
+      "Česko"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/cz.svg",
+      "png": "https://flagcdn.com/w320/cz.png"
+    }
+  },
+  {
+    "name": "Denmark",
+    "nativeName": "Danmark",
+    "demonym": "Danish",
+    "population": 5831404,
+    "altSpellings": [
+      "DK",
+      "Danmark",
+      "Kingdom of Denmark",
+      "Kongeriget Danmark"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/dk.svg",
+      "png": "https://flagcdn.com/w320/dk.png"
+    }
+  },
+  {
+    "name": "Djibouti",
+    "nativeName": "Djibouti",
+    "demonym": "Djibouti",
+    "population": 988002,
+    "altSpellings": [
+      "DJ",
+      "Jabuuti",
+      "Gabuuti",
+      "Republic of Djibouti",
+      "République de Djibouti",
+      "Gabuutih Ummuuno",
+      "Jamhuuriyadda Jabuuti"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/dj.svg",
+      "png": "https://flagcdn.com/w320/dj.png"
+    }
+  },
+  {
+    "name": "Dominica",
+    "nativeName": "Dominica",
+    "demonym": "Dominican",
+    "population": 71991,
+    "altSpellings": [
+      "DM",
+      "Dominique",
+      "Wai‘tu kubuli",
+      "Commonwealth of Dominica"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/dm.svg",
+      "png": "https://flagcdn.com/w320/dm.png"
+    }
+  },
+  {
+    "name": "Dominican Republic",
+    "nativeName": "República Dominicana",
+    "demonym": "Dominican",
+    "population": 10847904,
+    "altSpellings": [
+      "DO"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/do.svg",
+      "png": "https://flagcdn.com/w320/do.png"
+    }
+  },
+  {
+    "name": "Ecuador",
+    "nativeName": "Ecuador",
+    "demonym": "Ecuadorean",
+    "population": 17643060,
+    "altSpellings": [
+      "EC",
+      "Republic of Ecuador",
+      "República del Ecuador"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ec.svg",
+      "png": "https://flagcdn.com/w320/ec.png"
+    }
+  },
+  {
+    "name": "Egypt",
+    "nativeName": "مصر‎",
+    "demonym": "Egyptian",
+    "population": 102334403,
+    "altSpellings": [
+      "EG",
+      "Arab Republic of Egypt"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/eg.svg",
+      "png": "https://flagcdn.com/w320/eg.png"
+    }
+  },
+  {
+    "name": "El Salvador",
+    "nativeName": "El Salvador",
+    "demonym": "Salvadoran",
+    "population": 6486201,
+    "altSpellings": [
+      "SV",
+      "Republic of El Salvador",
+      "República de El Salvador"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sv.svg",
+      "png": "https://flagcdn.com/w320/sv.png"
+    }
+  },
+  {
+    "name": "Equatorial Guinea",
+    "nativeName": "Guinea Ecuatorial",
+    "demonym": "Equatorial Guinean",
+    "population": 1402985,
+    "altSpellings": [
+      "GQ",
+      "Republic of Equatorial Guinea",
+      "República de Guinea Ecuatorial",
+      "République de Guinée équatoriale",
+      "República da Guiné Equatorial"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gq.svg",
+      "png": "https://flagcdn.com/w320/gq.png"
+    }
+  },
+  {
+    "name": "Eritrea",
+    "nativeName": "ኤርትራ",
+    "demonym": "Eritrean",
+    "population": 5352000,
+    "altSpellings": [
+      "ER",
+      "State of Eritrea",
+      "ሃገረ ኤርትራ",
+      "Dawlat Iritriyá",
+      "ʾErtrā",
+      "Iritriyā",
+      ""
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/er.svg",
+      "png": "https://flagcdn.com/w320/er.png"
+    }
+  },
+  {
+    "name": "Estonia",
+    "nativeName": "Eesti",
+    "demonym": "Estonian",
+    "population": 1331057,
+    "altSpellings": [
+      "EE",
+      "Eesti",
+      "Republic of Estonia",
+      "Eesti Vabariik"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ee.svg",
+      "png": "https://flagcdn.com/w320/ee.png"
+    }
+  },
+  {
+    "name": "Ethiopia",
+    "nativeName": "ኢትዮጵያ",
+    "demonym": "Ethiopian",
+    "population": 114963583,
+    "altSpellings": [
+      "ET",
+      "ʾĪtyōṗṗyā",
+      "Federal Democratic Republic of Ethiopia",
+      "የኢትዮጵያ ፌዴራላዊ ዲሞክራሲያዊ ሪፐብሊክ"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/et.svg",
+      "png": "https://flagcdn.com/w320/et.png"
+    }
+  },
+  {
+    "name": "Falkland Islands (Malvinas)",
+    "nativeName": "Falkland Islands",
+    "demonym": "Falkland Islander",
+    "population": 2563,
+    "altSpellings": [
+      "FK",
+      "Islas Malvinas"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/fk.svg",
+      "png": "https://flagcdn.com/w320/fk.png"
+    }
+  },
+  {
+    "name": "Faroe Islands",
+    "nativeName": "Føroyar",
+    "demonym": "Faroese",
+    "population": 48865,
+    "altSpellings": [
+      "FO",
+      "Føroyar",
+      "Færøerne"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/fo.svg",
+      "png": "https://flagcdn.com/w320/fo.png"
+    }
+  },
+  {
+    "name": "Fiji",
+    "nativeName": "Fiji",
+    "demonym": "Fijian",
+    "population": 896444,
+    "altSpellings": [
+      "FJ",
+      "Viti",
+      "Republic of Fiji",
+      "Matanitu ko Viti",
+      "Fijī Gaṇarājya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/fj.svg",
+      "png": "https://flagcdn.com/w320/fj.png"
+    }
+  },
+  {
+    "name": "Finland",
+    "nativeName": "Suomi",
+    "demonym": "Finnish",
+    "population": 5530719,
+    "altSpellings": [
+      "FI",
+      "Suomi",
+      "Republic of Finland",
+      "Suomen tasavalta",
+      "Republiken Finland"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/fi.svg",
+      "png": "https://flagcdn.com/w320/fi.png"
+    }
+  },
+  {
+    "name": "France",
+    "nativeName": "France",
+    "demonym": "French",
+    "population": 67391582,
+    "altSpellings": [
+      "FR",
+      "French Republic",
+      "République française"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/fr.svg",
+      "png": "https://flagcdn.com/w320/fr.png"
+    }
+  },
+  {
+    "name": "French Guiana",
+    "nativeName": "Guyane française",
+    "demonym": "French Guianan",
+    "population": 254541,
+    "altSpellings": [
+      "GF",
+      "Guiana",
+      "Guyane"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gf.svg",
+      "png": "https://flagcdn.com/w320/gf.png"
+    }
+  },
+  {
+    "name": "French Polynesia",
+    "nativeName": "Polynésie française",
+    "demonym": "French Polynesian",
+    "population": 280904,
+    "altSpellings": [
+      "PF",
+      "Polynésie française",
+      "French Polynesia",
+      "Pōrīnetia Farāni"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pf.svg",
+      "png": "https://flagcdn.com/w320/pf.png"
+    }
+  },
+  {
+    "name": "French Southern Territories",
+    "nativeName": "Territoire des Terres australes et antarctiques françaises",
+    "demonym": "French",
+    "population": 140,
+    "altSpellings": [
+      "TF"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tf.svg",
+      "png": "https://flagcdn.com/w320/tf.png"
+    }
+  },
+  {
+    "name": "Gabon",
+    "nativeName": "Gabon",
+    "demonym": "Gabonese",
+    "population": 2225728,
+    "altSpellings": [
+      "GA",
+      "Gabonese Republic",
+      "République Gabonaise"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ga.svg",
+      "png": "https://flagcdn.com/w320/ga.png"
+    }
+  },
+  {
+    "name": "Gambia",
+    "nativeName": "Gambia",
+    "demonym": "Gambian",
+    "population": 2416664,
+    "altSpellings": [
+      "GM",
+      "Republic of the Gambia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gm.svg",
+      "png": "https://flagcdn.com/w320/gm.png"
+    }
+  },
+  {
+    "name": "Georgia",
+    "nativeName": "საქართველო",
+    "demonym": "Georgian",
+    "population": 3714000,
+    "altSpellings": [
+      "GE",
+      "Sakartvelo"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ge.svg",
+      "png": "https://flagcdn.com/w320/ge.png"
+    }
+  },
+  {
+    "name": "Germany",
+    "nativeName": "Deutschland",
+    "demonym": "German",
+    "population": 83240525,
+    "altSpellings": [
+      "DE",
+      "Federal Republic of Germany",
+      "Bundesrepublik Deutschland"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/de.svg",
+      "png": "https://flagcdn.com/w320/de.png"
+    }
+  },
+  {
+    "name": "Ghana",
+    "nativeName": "Ghana",
+    "demonym": "Ghanaian",
+    "population": 31072945,
+    "altSpellings": [
+      "GH"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gh.svg",
+      "png": "https://flagcdn.com/w320/gh.png"
+    }
+  },
+  {
+    "name": "Gibraltar",
+    "nativeName": "Gibraltar",
+    "demonym": "Gibraltar",
+    "population": 33691,
+    "altSpellings": [
+      "GI"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gi.svg",
+      "png": "https://flagcdn.com/w320/gi.png"
+    }
+  },
+  {
+    "name": "Greece",
+    "nativeName": "Ελλάδα",
+    "demonym": "Greek",
+    "population": 10715549,
+    "altSpellings": [
+      "GR",
+      "Elláda",
+      "Hellenic Republic",
+      "Ελληνική Δημοκρατία"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gr.svg",
+      "png": "https://flagcdn.com/w320/gr.png"
+    }
+  },
+  {
+    "name": "Greenland",
+    "nativeName": "Kalaallit Nunaat",
+    "demonym": "Greenlandic",
+    "population": 56367,
+    "altSpellings": [
+      "GL",
+      "Grønland"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gl.svg",
+      "png": "https://flagcdn.com/w320/gl.png"
+    }
+  },
+  {
+    "name": "Grenada",
+    "nativeName": "Grenada",
+    "demonym": "Grenadian",
+    "population": 112519,
+    "altSpellings": [
+      "GD"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gd.svg",
+      "png": "https://flagcdn.com/w320/gd.png"
+    }
+  },
+  {
+    "name": "Guadeloupe",
+    "nativeName": "Guadeloupe",
+    "demonym": "Guadeloupian",
+    "population": 400132,
+    "altSpellings": [
+      "GP",
+      "Gwadloup"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gp.svg",
+      "png": "https://flagcdn.com/w320/gp.png"
+    }
+  },
+  {
+    "name": "Guam",
+    "nativeName": "Guam",
+    "demonym": "Guamanian",
+    "population": 168783,
+    "altSpellings": [
+      "GU",
+      "Guåhån"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gu.svg",
+      "png": "https://flagcdn.com/w320/gu.png"
+    }
+  },
+  {
+    "name": "Guatemala",
+    "nativeName": "Guatemala",
+    "demonym": "Guatemalan",
+    "population": 16858333,
+    "altSpellings": [
+      "GT"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gt.svg",
+      "png": "https://flagcdn.com/w320/gt.png"
+    }
+  },
+  {
+    "name": "Guernsey",
+    "nativeName": "Guernsey",
+    "demonym": "Channel Islander",
+    "population": 62999,
+    "altSpellings": [
+      "GG",
+      "Bailiwick of Guernsey",
+      "Bailliage de Guernesey"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gg.svg",
+      "png": "https://flagcdn.com/w320/gg.png"
+    }
+  },
+  {
+    "name": "Guinea",
+    "nativeName": "Guinée",
+    "demonym": "Guinean",
+    "population": 13132792,
+    "altSpellings": [
+      "GN",
+      "Republic of Guinea",
+      "République de Guinée"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gn.svg",
+      "png": "https://flagcdn.com/w320/gn.png"
+    }
+  },
+  {
+    "name": "Guinea-Bissau",
+    "nativeName": "Guiné-Bissau",
+    "demonym": "Guinea-Bissauan",
+    "population": 1967998,
+    "altSpellings": [
+      "GW",
+      "Republic of Guinea-Bissau",
+      "República da Guiné-Bissau"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gw.svg",
+      "png": "https://flagcdn.com/w320/gw.png"
+    }
+  },
+  {
+    "name": "Guyana",
+    "nativeName": "Guyana",
+    "demonym": "Guyanese",
+    "population": 786559,
+    "altSpellings": [
+      "GY",
+      "Co-operative Republic of Guyana"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gy.svg",
+      "png": "https://flagcdn.com/w320/gy.png"
+    }
+  },
+  {
+    "name": "Haiti",
+    "nativeName": "Haïti",
+    "demonym": "Haitian",
+    "population": 11402533,
+    "altSpellings": [
+      "HT",
+      "Republic of Haiti",
+      "République d'Haïti",
+      "Repiblik Ayiti"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ht.svg",
+      "png": "https://flagcdn.com/w320/ht.png"
+    }
+  },
+  {
+    "name": "Heard Island and McDonald Islands",
+    "nativeName": "Heard Island and McDonald Islands",
+    "demonym": "Heard and McDonald Islander",
+    "population": 0,
+    "altSpellings": [
+      "HM"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/hm.svg",
+      "png": "https://flagcdn.com/w320/hm.png"
+    }
+  },
+  {
+    "name": "Vatican City",
+    "nativeName": "Status Civitatis Vaticanae",
+    "demonym": "Vatican",
+    "population": 451,
+    "altSpellings": [
+      "Vatican",
+      "The Vatican"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/va.svg",
+      "png": "https://flagcdn.com/w320/va.png"
+    }
+  },
+  {
+    "name": "Honduras",
+    "nativeName": "Honduras",
+    "demonym": "Honduran",
+    "population": 9904608,
+    "altSpellings": [
+      "HN",
+      "Republic of Honduras",
+      "República de Honduras"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/hn.svg",
+      "png": "https://flagcdn.com/w320/hn.png"
+    }
+  },
+  {
+    "name": "Hungary",
+    "nativeName": "Magyarország",
+    "demonym": "Hungarian",
+    "population": 9749763,
+    "altSpellings": [
+      "HU"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/hu.svg",
+      "png": "https://flagcdn.com/w320/hu.png"
+    }
+  },
+  {
+    "name": "Hong Kong",
+    "nativeName": "香港",
+    "demonym": "Chinese",
+    "population": 7481800,
+    "altSpellings": [
+      "HK",
+      "香港"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/hk.svg",
+      "png": "https://flagcdn.com/w320/hk.png"
+    }
+  },
+  {
+    "name": "Iceland",
+    "nativeName": "Ísland",
+    "demonym": "Icelander",
+    "population": 366425,
+    "altSpellings": [
+      "IS",
+      "Island",
+      "Republic of Iceland",
+      "Lýðveldið Ísland"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/is.svg",
+      "png": "https://flagcdn.com/w320/is.png"
+    }
+  },
+  {
+    "name": "India",
+    "nativeName": "भारत",
+    "demonym": "Indian",
+    "population": 1380004385,
+    "altSpellings": [
+      "IN",
+      "Bhārat",
+      "Republic of India",
+      "Bharat Ganrajya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/in.svg",
+      "png": "https://flagcdn.com/w320/in.png"
+    }
+  },
+  {
+    "name": "Indonesia",
+    "nativeName": "Indonesia",
+    "demonym": "Indonesian",
+    "population": 273523621,
+    "altSpellings": [
+      "ID",
+      "Republic of Indonesia",
+      "Republik Indonesia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/id.svg",
+      "png": "https://flagcdn.com/w320/id.png"
+    }
+  },
+  {
+    "name": "Ivory Coast",
+    "nativeName": "Côte d'Ivoire",
+    "demonym": "Ivorian",
+    "population": 26378275,
+    "altSpellings": [
+      "CI",
+      "Ivory Coast",
+      "Republic of Côte d'Ivoire",
+      "République de Côte d'Ivoire"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ci.svg",
+      "png": "https://flagcdn.com/w320/ci.png"
+    }
+  },
+  {
+    "name": "Iran (Islamic Republic of)",
+    "nativeName": "ایران",
+    "demonym": "Iranian",
+    "population": 83992953,
+    "altSpellings": [
+      "IR",
+      "Islamic Republic of Iran",
+      "Jomhuri-ye Eslāmi-ye Irān"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ir.svg",
+      "png": "https://flagcdn.com/w320/ir.png"
+    }
+  },
+  {
+    "name": "Iraq",
+    "nativeName": "العراق",
+    "demonym": "Iraqi",
+    "population": 40222503,
+    "altSpellings": [
+      "IQ",
+      "Republic of Iraq",
+      "Jumhūriyyat al-‘Irāq"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/iq.svg",
+      "png": "https://flagcdn.com/w320/iq.png"
+    }
+  },
+  {
+    "name": "Ireland",
+    "nativeName": "Éire",
+    "demonym": "Irish",
+    "population": 4994724,
+    "altSpellings": [
+      "IE",
+      "Éire",
+      "Republic of Ireland",
+      "Poblacht na hÉireann"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ie.svg",
+      "png": "https://flagcdn.com/w320/ie.png"
+    }
+  },
+  {
+    "name": "Isle of Man",
+    "nativeName": "Isle of Man",
+    "demonym": "Manx",
+    "population": 85032,
+    "altSpellings": [
+      "IM",
+      "Ellan Vannin",
+      "Mann",
+      "Mannin"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/im.svg",
+      "png": "https://flagcdn.com/w320/im.png"
+    }
+  },
+  {
+    "name": "Israel",
+    "nativeName": "יִשְׂרָאֵל",
+    "demonym": "Israeli",
+    "population": 9216900,
+    "altSpellings": [
+      "IL",
+      "State of Israel",
+      "Medīnat Yisrā'el"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/il.svg",
+      "png": "https://flagcdn.com/w320/il.png"
+    }
+  },
+  {
+    "name": "Italy",
+    "nativeName": "Italia",
+    "demonym": "Italian",
+    "population": 59554023,
+    "altSpellings": [
+      "IT",
+      "Italian Republic",
+      "Repubblica italiana"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/it.svg",
+      "png": "https://flagcdn.com/w320/it.png"
+    }
+  },
+  {
+    "name": "Jamaica",
+    "nativeName": "Jamaica",
+    "demonym": "Jamaican",
+    "population": 2961161,
+    "altSpellings": [
+      "JM"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/jm.svg",
+      "png": "https://flagcdn.com/w320/jm.png"
+    }
+  },
+  {
+    "name": "Japan",
+    "nativeName": "日本",
+    "demonym": "Japanese",
+    "population": 125836021,
+    "altSpellings": [
+      "JP",
+      "Nippon",
+      "Nihon"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/jp.svg",
+      "png": "https://flagcdn.com/w320/jp.png"
+    }
+  },
+  {
+    "name": "Jersey",
+    "nativeName": "Jersey",
+    "demonym": "Channel Islander",
+    "population": 100800,
+    "altSpellings": [
+      "JE",
+      "Bailiwick of Jersey",
+      "Bailliage de Jersey",
+      "Bailliage dé Jèrri"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/je.svg",
+      "png": "https://flagcdn.com/w320/je.png"
+    }
+  },
+  {
+    "name": "Jordan",
+    "nativeName": "الأردن",
+    "demonym": "Jordanian",
+    "population": 10203140,
+    "altSpellings": [
+      "JO",
+      "Hashemite Kingdom of Jordan",
+      "al-Mamlakah al-Urdunīyah al-Hāshimīyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/jo.svg",
+      "png": "https://flagcdn.com/w320/jo.png"
+    }
+  },
+  {
+    "name": "Kazakhstan",
+    "nativeName": "Қазақстан",
+    "demonym": "Kazakhstani",
+    "population": 18754440,
+    "altSpellings": [
+      "KZ",
+      "Qazaqstan",
+      "Казахстан",
+      "Republic of Kazakhstan",
+      "Қазақстан Республикасы",
+      "Qazaqstan Respublïkası",
+      "Республика Казахстан",
+      "Respublika Kazakhstan"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kz.svg",
+      "png": "https://flagcdn.com/w320/kz.png"
+    }
+  },
+  {
+    "name": "Kenya",
+    "nativeName": "Kenya",
+    "demonym": "Kenyan",
+    "population": 53771300,
+    "altSpellings": [
+      "KE",
+      "Republic of Kenya",
+      "Jamhuri ya Kenya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ke.svg",
+      "png": "https://flagcdn.com/w320/ke.png"
+    }
+  },
+  {
+    "name": "Kiribati",
+    "nativeName": "Kiribati",
+    "demonym": "I-Kiribati",
+    "population": 119446,
+    "altSpellings": [
+      "KI",
+      "Republic of Kiribati",
+      "Ribaberiki Kiribati"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ki.svg",
+      "png": "https://flagcdn.com/w320/ki.png"
+    }
+  },
+  {
+    "name": "Kuwait",
+    "nativeName": "الكويت",
+    "demonym": "Kuwaiti",
+    "population": 4270563,
+    "altSpellings": [
+      "KW",
+      "State of Kuwait",
+      "Dawlat al-Kuwait"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kw.svg",
+      "png": "https://flagcdn.com/w320/kw.png"
+    }
+  },
+  {
+    "name": "Kyrgyzstan",
+    "nativeName": "Кыргызстан",
+    "demonym": "Kirghiz",
+    "population": 6591600,
+    "altSpellings": [
+      "KG",
+      "Киргизия",
+      "Kyrgyz Republic",
+      "Кыргыз Республикасы",
+      "Kyrgyz Respublikasy"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kg.svg",
+      "png": "https://flagcdn.com/w320/kg.png"
+    }
+  },
+  {
+    "name": "Lao People's Democratic Republic",
+    "nativeName": "ສາທາລະນະລັດ ປະຊາທິປະໄຕ ປະຊາຊົນລາວ",
+    "demonym": "Laotian",
+    "population": 7275556,
+    "altSpellings": [
+      "LA",
+      "Lao",
+      "Laos",
+      "Lao People's Democratic Republic",
+      "Sathalanalat Paxathipatai Paxaxon Lao"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/la.svg",
+      "png": "https://flagcdn.com/w320/la.png"
+    }
+  },
+  {
+    "name": "Latvia",
+    "nativeName": "Latvija",
+    "demonym": "Latvian",
+    "population": 1901548,
+    "altSpellings": [
+      "LV",
+      "Republic of Latvia",
+      "Latvijas Republika"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lv.svg",
+      "png": "https://flagcdn.com/w320/lv.png"
+    }
+  },
+  {
+    "name": "Lebanon",
+    "nativeName": "لبنان",
+    "demonym": "Lebanese",
+    "population": 6825442,
+    "altSpellings": [
+      "LB",
+      "Lebanese Republic",
+      "Al-Jumhūrīyah Al-Libnānīyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lb.svg",
+      "png": "https://flagcdn.com/w320/lb.png"
+    }
+  },
+  {
+    "name": "Lesotho",
+    "nativeName": "Lesotho",
+    "demonym": "Mosotho",
+    "population": 2142252,
+    "altSpellings": [
+      "LS",
+      "Kingdom of Lesotho",
+      "Muso oa Lesotho"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ls.svg",
+      "png": "https://flagcdn.com/w320/ls.png"
+    }
+  },
+  {
+    "name": "Liberia",
+    "nativeName": "Liberia",
+    "demonym": "Liberian",
+    "population": 5057677,
+    "altSpellings": [
+      "LR",
+      "Republic of Liberia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lr.svg",
+      "png": "https://flagcdn.com/w320/lr.png"
+    }
+  },
+  {
+    "name": "Libya",
+    "nativeName": "‏ليبيا",
+    "demonym": "Libyan",
+    "population": 6871287,
+    "altSpellings": [
+      "LY",
+      "State of Libya",
+      "Dawlat Libya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ly.svg",
+      "png": "https://flagcdn.com/w320/ly.png"
+    }
+  },
+  {
+    "name": "Liechtenstein",
+    "nativeName": "Liechtenstein",
+    "demonym": "Liechtensteiner",
+    "population": 38137,
+    "altSpellings": [
+      "LI",
+      "Principality of Liechtenstein",
+      "Fürstentum Liechtenstein"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/li.svg",
+      "png": "https://flagcdn.com/w320/li.png"
+    }
+  },
+  {
+    "name": "Lithuania",
+    "nativeName": "Lietuva",
+    "demonym": "Lithuanian",
+    "population": 2794700,
+    "altSpellings": [
+      "LT",
+      "Republic of Lithuania",
+      "Lietuvos Respublika"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lt.svg",
+      "png": "https://flagcdn.com/w320/lt.png"
+    }
+  },
+  {
+    "name": "Luxembourg",
+    "nativeName": "Lëtzebuerg",
+    "demonym": "Luxembourger",
+    "population": 632275,
+    "altSpellings": [
+      "LU",
+      "Grand Duchy of Luxembourg",
+      "Grand-Duché de Luxembourg",
+      "Großherzogtum Luxemburg",
+      "Groussherzogtum Lëtzebuerg"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lu.svg",
+      "png": "https://flagcdn.com/w320/lu.png"
+    }
+  },
+  {
+    "name": "Macao",
+    "nativeName": "澳門",
+    "demonym": "Chinese",
+    "population": 649342,
+    "altSpellings": [
+      "MO",
+      "澳门",
+      "Macao Special Administrative Region of the People's Republic of China",
+      "中華人民共和國澳門特別行政區",
+      "Região Administrativa Especial de Macau da República Popular da China"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mo.svg",
+      "png": "https://flagcdn.com/w320/mo.png"
+    }
+  },
+  {
+    "name": "North Macedonia",
+    "nativeName": "Македонија",
+    "demonym": "Macedonian",
+    "population": 2083380,
+    "altSpellings": [
+      "MK",
+      "Republic of Macedonia",
+      "Република Македонија"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mk.svg",
+      "png": "https://flagcdn.com/w320/mk.png"
+    }
+  },
+  {
+    "name": "Madagascar",
+    "nativeName": "Madagasikara",
+    "demonym": "Malagasy",
+    "population": 27691019,
+    "altSpellings": [
+      "MG",
+      "Republic of Madagascar",
+      "Repoblikan'i Madagasikara",
+      "République de Madagascar"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mg.svg",
+      "png": "https://flagcdn.com/w320/mg.png"
+    }
+  },
+  {
+    "name": "Malawi",
+    "nativeName": "Malawi",
+    "demonym": "Malawian",
+    "population": 19129955,
+    "altSpellings": [
+      "MW",
+      "Republic of Malawi"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mw.svg",
+      "png": "https://flagcdn.com/w320/mw.png"
+    }
+  },
+  {
+    "name": "Malaysia",
+    "nativeName": "Malaysia",
+    "demonym": "Malaysian",
+    "population": 32365998,
+    "altSpellings": [
+      "MY"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/my.svg",
+      "png": "https://flagcdn.com/w320/my.png"
+    }
+  },
+  {
+    "name": "Maldives",
+    "nativeName": "Maldives",
+    "demonym": "Maldivan",
+    "population": 540542,
+    "altSpellings": [
+      "MV",
+      "Maldive Islands",
+      "Republic of the Maldives",
+      "Dhivehi Raajjeyge Jumhooriyya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mv.svg",
+      "png": "https://flagcdn.com/w320/mv.png"
+    }
+  },
+  {
+    "name": "Mali",
+    "nativeName": "Mali",
+    "demonym": "Malian",
+    "population": 20250834,
+    "altSpellings": [
+      "ML",
+      "Republic of Mali",
+      "République du Mali"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ml.svg",
+      "png": "https://flagcdn.com/w320/ml.png"
+    }
+  },
+  {
+    "name": "Malta",
+    "nativeName": "Malta",
+    "demonym": "Maltese",
+    "population": 525285,
+    "altSpellings": [
+      "MT",
+      "Republic of Malta",
+      "Repubblika ta' Malta"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mt.svg",
+      "png": "https://flagcdn.com/w320/mt.png"
+    }
+  },
+  {
+    "name": "Marshall Islands",
+    "nativeName": "M̧ajeļ",
+    "demonym": "Marshallese",
+    "population": 59194,
+    "altSpellings": [
+      "MH",
+      "Republic of the Marshall Islands",
+      "Aolepān Aorōkin M̧ajeļ"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mh.svg",
+      "png": "https://flagcdn.com/w320/mh.png"
+    }
+  },
+  {
+    "name": "Martinique",
+    "nativeName": "Martinique",
+    "demonym": "French",
+    "population": 378243,
+    "altSpellings": [
+      "MQ"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mq.svg",
+      "png": "https://flagcdn.com/w320/mq.png"
+    }
+  },
+  {
+    "name": "Mauritania",
+    "nativeName": "موريتانيا",
+    "demonym": "Mauritanian",
+    "population": 4649660,
+    "altSpellings": [
+      "MR",
+      "Islamic Republic of Mauritania",
+      "al-Jumhūriyyah al-ʾIslāmiyyah al-Mūrītāniyyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mr.svg",
+      "png": "https://flagcdn.com/w320/mr.png"
+    }
+  },
+  {
+    "name": "Mauritius",
+    "nativeName": "Maurice",
+    "demonym": "Mauritian",
+    "population": 1265740,
+    "altSpellings": [
+      "MU",
+      "Republic of Mauritius",
+      "République de Maurice"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mu.svg",
+      "png": "https://flagcdn.com/w320/mu.png"
+    }
+  },
+  {
+    "name": "Mayotte",
+    "nativeName": "Mayotte",
+    "demonym": "French",
+    "population": 226915,
+    "altSpellings": [
+      "YT",
+      "Department of Mayotte",
+      "Département de Mayotte"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/yt.svg",
+      "png": "https://flagcdn.com/w320/yt.png"
+    }
+  },
+  {
+    "name": "Mexico",
+    "nativeName": "México",
+    "demonym": "Mexican",
+    "population": 128932753,
+    "altSpellings": [
+      "MX",
+      "Mexicanos",
+      "United Mexican States",
+      "Estados Unidos Mexicanos"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mx.svg",
+      "png": "https://flagcdn.com/w320/mx.png"
+    }
+  },
+  {
+    "name": "Micronesia (Federated States of)",
+    "nativeName": "Micronesia",
+    "demonym": "Micronesian",
+    "population": 115021,
+    "altSpellings": [
+      "FM",
+      "Federated States of Micronesia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/fm.svg",
+      "png": "https://flagcdn.com/w320/fm.png"
+    }
+  },
+  {
+    "name": "Moldova (Republic of)",
+    "nativeName": "Moldova",
+    "demonym": "Moldovan",
+    "population": 2617820,
+    "altSpellings": [
+      "MD",
+      "Republic of Moldova",
+      "Republica Moldova"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/md.svg",
+      "png": "https://flagcdn.com/w320/md.png"
+    }
+  },
+  {
+    "name": "Monaco",
+    "nativeName": "Monaco",
+    "demonym": "Monegasque",
+    "population": 39244,
+    "altSpellings": [
+      "MC",
+      "Principality of Monaco",
+      "Principauté de Monaco"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mc.svg",
+      "png": "https://flagcdn.com/w320/mc.png"
+    }
+  },
+  {
+    "name": "Mongolia",
+    "nativeName": "Монгол улс",
+    "demonym": "Mongolian",
+    "population": 3278292,
+    "altSpellings": [
+      "MN"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mn.svg",
+      "png": "https://flagcdn.com/w320/mn.png"
+    }
+  },
+  {
+    "name": "Montenegro",
+    "nativeName": "Црна Гора",
+    "demonym": "Montenegrin",
+    "population": 621718,
+    "altSpellings": [
+      "ME",
+      "Crna Gora"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/me.svg",
+      "png": "https://flagcdn.com/w320/me.png"
+    }
+  },
+  {
+    "name": "Montserrat",
+    "nativeName": "Montserrat",
+    "demonym": "Montserratian",
+    "population": 4922,
+    "altSpellings": [
+      "MS"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ms.svg",
+      "png": "https://flagcdn.com/w320/ms.png"
+    }
+  },
+  {
+    "name": "Morocco",
+    "nativeName": "المغرب",
+    "demonym": "Moroccan",
+    "population": 36910558,
+    "altSpellings": [
+      "MA",
+      "Kingdom of Morocco",
+      "Al-Mamlakah al-Maġribiyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ma.svg",
+      "png": "https://flagcdn.com/w320/ma.png"
+    }
+  },
+  {
+    "name": "Mozambique",
+    "nativeName": "Moçambique",
+    "demonym": "Mozambican",
+    "population": 31255435,
+    "altSpellings": [
+      "MZ",
+      "Republic of Mozambique",
+      "República de Moçambique"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mz.svg",
+      "png": "https://flagcdn.com/w320/mz.png"
+    }
+  },
+  {
+    "name": "Myanmar",
+    "nativeName": "Myanma",
+    "demonym": "Burmese",
+    "population": 54409794,
+    "altSpellings": [
+      "MM",
+      "Burma",
+      "Republic of the Union of Myanmar",
+      "Pyidaunzu Thanmăda Myăma Nainngandaw"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mm.svg",
+      "png": "https://flagcdn.com/w320/mm.png"
+    }
+  },
+  {
+    "name": "Namibia",
+    "nativeName": "Namibia",
+    "demonym": "Namibian",
+    "population": 2540916,
+    "altSpellings": [
+      "NA",
+      "Namibië",
+      "Republic of Namibia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/na.svg",
+      "png": "https://flagcdn.com/w320/na.png"
+    }
+  },
+  {
+    "name": "Nauru",
+    "nativeName": "Nauru",
+    "demonym": "Nauruan",
+    "population": 10834,
+    "altSpellings": [
+      "NR",
+      "Naoero",
+      "Pleasant Island",
+      "Republic of Nauru",
+      "Ripublik Naoero"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/nr.svg",
+      "png": "https://flagcdn.com/w320/nr.png"
+    }
+  },
+  {
+    "name": "Nepal",
+    "nativeName": "नेपाल",
+    "demonym": "Nepalese",
+    "population": 29136808,
+    "altSpellings": [
+      "NP",
+      "Federal Democratic Republic of Nepal",
+      "Loktāntrik Ganatantra Nepāl"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/np.svg",
+      "png": "https://flagcdn.com/w320/np.png"
+    }
+  },
+  {
+    "name": "Netherlands",
+    "nativeName": "Nederland",
+    "demonym": "Dutch",
+    "population": 17441139,
+    "altSpellings": [
+      "NL",
+      "Holland",
+      "Nederland"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/nl.svg",
+      "png": "https://flagcdn.com/w320/nl.png"
+    }
+  },
+  {
+    "name": "New Caledonia",
+    "nativeName": "Nouvelle-Calédonie",
+    "demonym": "New Caledonian",
+    "population": 271960,
+    "altSpellings": [
+      "NC"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/nc.svg",
+      "png": "https://flagcdn.com/w320/nc.png"
+    }
+  },
+  {
+    "name": "New Zealand",
+    "nativeName": "New Zealand",
+    "demonym": "New Zealander",
+    "population": 5084300,
+    "altSpellings": [
+      "NZ",
+      "Aotearoa"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/nz.svg",
+      "png": "https://flagcdn.com/w320/nz.png"
+    }
+  },
+  {
+    "name": "Nicaragua",
+    "nativeName": "Nicaragua",
+    "demonym": "Nicaraguan",
+    "population": 6624554,
+    "altSpellings": [
+      "NI",
+      "Republic of Nicaragua",
+      "República de Nicaragua"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ni.svg",
+      "png": "https://flagcdn.com/w320/ni.png"
+    }
+  },
+  {
+    "name": "Niger",
+    "nativeName": "Niger",
+    "demonym": "Nigerien",
+    "population": 24206636,
+    "altSpellings": [
+      "NE",
+      "Nijar",
+      "Republic of Niger",
+      "République du Niger"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ne.svg",
+      "png": "https://flagcdn.com/w320/ne.png"
+    }
+  },
+  {
+    "name": "Nigeria",
+    "nativeName": "Nigeria",
+    "demonym": "Nigerian",
+    "population": 206139587,
+    "altSpellings": [
+      "NG",
+      "Nijeriya",
+      "Naíjíríà",
+      "Federal Republic of Nigeria"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ng.svg",
+      "png": "https://flagcdn.com/w320/ng.png"
+    }
+  },
+  {
+    "name": "Niue",
+    "nativeName": "Niuē",
+    "demonym": "Niuean",
+    "population": 1470,
+    "altSpellings": [
+      "NU"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/nu.svg",
+      "png": "https://flagcdn.com/w320/nu.png"
+    }
+  },
+  {
+    "name": "Norfolk Island",
+    "nativeName": "Norfolk Island",
+    "demonym": "Norfolk Islander",
+    "population": 2302,
+    "altSpellings": [
+      "NF",
+      "Territory of Norfolk Island",
+      "Teratri of Norf'k Ailen"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/nf.svg",
+      "png": "https://flagcdn.com/w320/nf.png"
+    }
+  },
+  {
+    "name": "Korea (Democratic People's Republic of)",
+    "nativeName": "북한",
+    "demonym": "North Korean",
+    "population": 25778815,
+    "altSpellings": [
+      "KP",
+      "Democratic People's Republic of Korea",
+      "조선민주주의인민공화국",
+      "Chosŏn Minjujuŭi Inmin Konghwaguk"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kp.svg",
+      "png": "https://flagcdn.com/w320/kp.png"
+    }
+  },
+  {
+    "name": "Northern Mariana Islands",
+    "nativeName": "Northern Mariana Islands",
+    "demonym": "American",
+    "population": 57557,
+    "altSpellings": [
+      "MP",
+      "Commonwealth of the Northern Mariana Islands",
+      "Sankattan Siha Na Islas Mariånas"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mp.svg",
+      "png": "https://flagcdn.com/w320/mp.png"
+    }
+  },
+  {
+    "name": "Norway",
+    "nativeName": "Norge",
+    "demonym": "Norwegian",
+    "population": 5379475,
+    "altSpellings": [
+      "NO",
+      "Norge",
+      "Noreg",
+      "Kingdom of Norway",
+      "Kongeriket Norge",
+      "Kongeriket Noreg"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/no.svg",
+      "png": "https://flagcdn.com/w320/no.png"
+    }
+  },
+  {
+    "name": "Oman",
+    "nativeName": "عمان",
+    "demonym": "Omani",
+    "population": 5106622,
+    "altSpellings": [
+      "OM",
+      "Sultanate of Oman",
+      "Salṭanat ʻUmān"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/om.svg",
+      "png": "https://flagcdn.com/w320/om.png"
+    }
+  },
+  {
+    "name": "Pakistan",
+    "nativeName": "Pakistan",
+    "demonym": "Pakistani",
+    "population": 220892331,
+    "altSpellings": [
+      "PK",
+      "Pākistān",
+      "Islamic Republic of Pakistan",
+      "Islāmī Jumhūriya'eh Pākistān"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pk.svg",
+      "png": "https://flagcdn.com/w320/pk.png"
+    }
+  },
+  {
+    "name": "Palau",
+    "nativeName": "Palau",
+    "demonym": "Palauan",
+    "population": 18092,
+    "altSpellings": [
+      "PW",
+      "Republic of Palau",
+      "Beluu er a Belau"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pw.svg",
+      "png": "https://flagcdn.com/w320/pw.png"
+    }
+  },
+  {
+    "name": "Palestine, State of",
+    "nativeName": "فلسطين",
+    "demonym": "Palestinian",
+    "population": 4803269,
+    "altSpellings": [
+      "PS",
+      "State of Palestine",
+      "Dawlat Filasṭin"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ps.svg",
+      "png": "https://flagcdn.com/w320/ps.png"
+    }
+  },
+  {
+    "name": "Panama",
+    "nativeName": "Panamá",
+    "demonym": "Panamanian",
+    "population": 4314768,
+    "altSpellings": [
+      "PA",
+      "Republic of Panama",
+      "República de Panamá"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pa.svg",
+      "png": "https://flagcdn.com/w320/pa.png"
+    }
+  },
+  {
+    "name": "Papua New Guinea",
+    "nativeName": "Papua Niugini",
+    "demonym": "Papua New Guinean",
+    "population": 8947027,
+    "altSpellings": [
+      "PG",
+      "Independent State of Papua New Guinea",
+      "Independen Stet bilong Papua Niugini"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pg.svg",
+      "png": "https://flagcdn.com/w320/pg.png"
+    }
+  },
+  {
+    "name": "Paraguay",
+    "nativeName": "Paraguay",
+    "demonym": "Paraguayan",
+    "population": 7132530,
+    "altSpellings": [
+      "PY",
+      "Republic of Paraguay",
+      "República del Paraguay",
+      "Tetã Paraguái"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/py.svg",
+      "png": "https://flagcdn.com/w320/py.png"
+    }
+  },
+  {
+    "name": "Peru",
+    "nativeName": "Perú",
+    "demonym": "Peruvian",
+    "population": 32971846,
+    "altSpellings": [
+      "PE",
+      "Republic of Peru",
+      " República del Perú"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pe.svg",
+      "png": "https://flagcdn.com/w320/pe.png"
+    }
+  },
+  {
+    "name": "Philippines",
+    "nativeName": "Pilipinas",
+    "demonym": "Filipino",
+    "population": 109581085,
+    "altSpellings": [
+      "PH",
+      "Republic of the Philippines",
+      "Repúblika ng Pilipinas"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ph.svg",
+      "png": "https://flagcdn.com/w320/ph.png"
+    }
+  },
+  {
+    "name": "Pitcairn",
+    "nativeName": "Pitcairn Islands",
+    "demonym": "Pitcairn Islander",
+    "population": 56,
+    "altSpellings": [
+      "PN",
+      "Pitcairn Henderson Ducie and Oeno Islands"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pn.svg",
+      "png": "https://flagcdn.com/w320/pn.png"
+    }
+  },
+  {
+    "name": "Poland",
+    "nativeName": "Polska",
+    "demonym": "Polish",
+    "population": 37950802,
+    "altSpellings": [
+      "PL",
+      "Republic of Poland",
+      "Rzeczpospolita Polska"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pl.svg",
+      "png": "https://flagcdn.com/w320/pl.png"
+    }
+  },
+  {
+    "name": "Portugal",
+    "nativeName": "Portugal",
+    "demonym": "Portuguese",
+    "population": 10305564,
+    "altSpellings": [
+      "PT",
+      "Portuguesa",
+      "Portuguese Republic",
+      "República Portuguesa"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pt.svg",
+      "png": "https://flagcdn.com/w320/pt.png"
+    }
+  },
+  {
+    "name": "Puerto Rico",
+    "nativeName": "Puerto Rico",
+    "demonym": "Puerto Rican",
+    "population": 3194034,
+    "altSpellings": [
+      "PR",
+      "Commonwealth of Puerto Rico",
+      "Estado Libre Asociado de Puerto Rico"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pr.svg",
+      "png": "https://flagcdn.com/w320/pr.png"
+    }
+  },
+  {
+    "name": "Qatar",
+    "nativeName": "قطر",
+    "demonym": "Qatari",
+    "population": 2881060,
+    "altSpellings": [
+      "QA",
+      "State of Qatar",
+      "Dawlat Qaṭar"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/qa.svg",
+      "png": "https://flagcdn.com/w320/qa.png"
+    }
+  },
+  {
+    "name": "Republic of Kosovo",
+    "nativeName": "Republika e Kosovës",
+    "demonym": "Kosovar",
+    "population": 1775378,
+    "altSpellings": [
+      "XK",
+      "Република Косово"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/xk.svg",
+      "png": "https://flagcdn.com/w320/xk.png"
+    }
+  },
+  {
+    "name": "Réunion",
+    "nativeName": "La Réunion",
+    "demonym": "French",
+    "population": 840974,
+    "altSpellings": [
+      "RE",
+      "Reunion"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/re.svg",
+      "png": "https://flagcdn.com/w320/re.png"
+    }
+  },
+  {
+    "name": "Romania",
+    "nativeName": "România",
+    "demonym": "Romanian",
+    "population": 19286123,
+    "altSpellings": [
+      "RO",
+      "Rumania",
+      "Roumania",
+      "România"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ro.svg",
+      "png": "https://flagcdn.com/w320/ro.png"
+    }
+  },
+  {
+    "name": "Russian Federation",
+    "nativeName": "Россия",
+    "demonym": "Russian",
+    "population": 144104080,
+    "altSpellings": [
+      "RU",
+      "Rossiya",
+      "Russian Federation",
+      "Российская Федерация",
+      "Rossiyskaya Federatsiya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ru.svg",
+      "png": "https://flagcdn.com/w320/ru.png"
+    }
+  },
+  {
+    "name": "Rwanda",
+    "nativeName": "Rwanda",
+    "demonym": "Rwandan",
+    "population": 12952209,
+    "altSpellings": [
+      "RW",
+      "Republic of Rwanda",
+      "Repubulika y'u Rwanda",
+      "République du Rwanda"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/rw.svg",
+      "png": "https://flagcdn.com/w320/rw.png"
+    }
+  },
+  {
+    "name": "Saint Barthélemy",
+    "nativeName": "Saint-Barthélemy",
+    "demonym": "Saint Barthélemy Islander",
+    "population": 9417,
+    "altSpellings": [
+      "BL",
+      "St. Barthelemy",
+      "Collectivity of Saint Barthélemy",
+      "Collectivité de Saint-Barthélemy"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/bl.svg",
+      "png": "https://flagcdn.com/w320/bl.png"
+    }
+  },
+  {
+    "name": "Saint Helena, Ascension and Tristan da Cunha",
+    "nativeName": "Saint Helena",
+    "demonym": "Saint Helenian",
+    "population": 4255,
+    "altSpellings": [
+      "SH"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sh.svg",
+      "png": "https://flagcdn.com/w320/sh.png"
+    }
+  },
+  {
+    "name": "Saint Kitts and Nevis",
+    "nativeName": "Saint Kitts and Nevis",
+    "demonym": "Kittian and Nevisian",
+    "population": 53192,
+    "altSpellings": [
+      "KN",
+      "Federation of Saint Christopher and Nevis"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kn.svg",
+      "png": "https://flagcdn.com/w320/kn.png"
+    }
+  },
+  {
+    "name": "Saint Lucia",
+    "nativeName": "Saint Lucia",
+    "demonym": "Saint Lucian",
+    "population": 183629,
+    "altSpellings": [
+      "LC"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lc.svg",
+      "png": "https://flagcdn.com/w320/lc.png"
+    }
+  },
+  {
+    "name": "Saint Martin (French part)",
+    "nativeName": "Saint-Martin",
+    "demonym": "Saint Martin Islander",
+    "population": 38659,
+    "altSpellings": [
+      "MF",
+      "Collectivity of Saint Martin",
+      "Collectivité de Saint-Martin"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/mf.svg",
+      "png": "https://flagcdn.com/w320/mf.png"
+    }
+  },
+  {
+    "name": "Saint Pierre and Miquelon",
+    "nativeName": "Saint-Pierre-et-Miquelon",
+    "demonym": "French",
+    "population": 6069,
+    "altSpellings": [
+      "PM",
+      "Collectivité territoriale de Saint-Pierre-et-Miquelon"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/pm.svg",
+      "png": "https://flagcdn.com/w320/pm.png"
+    }
+  },
+  {
+    "name": "Saint Vincent and the Grenadines",
+    "nativeName": "Saint Vincent and the Grenadines",
+    "demonym": "Saint Vincentian",
+    "population": 110947,
+    "altSpellings": [
+      "VC"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/vc.svg",
+      "png": "https://flagcdn.com/w320/vc.png"
+    }
+  },
+  {
+    "name": "Samoa",
+    "nativeName": "Samoa",
+    "demonym": "Samoan",
+    "population": 198410,
+    "altSpellings": [
+      "WS",
+      "Independent State of Samoa",
+      "Malo Saʻoloto Tutoʻatasi o Sāmoa"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ws.svg",
+      "png": "https://flagcdn.com/w320/ws.png"
+    }
+  },
+  {
+    "name": "San Marino",
+    "nativeName": "San Marino",
+    "demonym": "Sammarinese",
+    "population": 33938,
+    "altSpellings": [
+      "SM",
+      "Republic of San Marino",
+      "Repubblica di San Marino"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sm.svg",
+      "png": "https://flagcdn.com/w320/sm.png"
+    }
+  },
+  {
+    "name": "Sao Tome and Principe",
+    "nativeName": "São Tomé e Príncipe",
+    "demonym": "Sao Tomean",
+    "population": 219161,
+    "altSpellings": [
+      "ST",
+      "Democratic Republic of São Tomé and Príncipe",
+      "República Democrática de São Tomé e Príncipe"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/st.svg",
+      "png": "https://flagcdn.com/w320/st.png"
+    }
+  },
+  {
+    "name": "Saudi Arabia",
+    "nativeName": "العربية السعودية",
+    "demonym": "Saudi Arabian",
+    "population": 34813867,
+    "altSpellings": [
+      "SA",
+      "Kingdom of Saudi Arabia",
+      "Al-Mamlakah al-‘Arabiyyah as-Su‘ūdiyyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sa.svg",
+      "png": "https://flagcdn.com/w320/sa.png"
+    }
+  },
+  {
+    "name": "Senegal",
+    "nativeName": "Sénégal",
+    "demonym": "Senegalese",
+    "population": 16743930,
+    "altSpellings": [
+      "SN",
+      "Republic of Senegal",
+      "République du Sénégal"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sn.svg",
+      "png": "https://flagcdn.com/w320/sn.png"
+    }
+  },
+  {
+    "name": "Serbia",
+    "nativeName": "Србија",
+    "demonym": "Serbian",
+    "population": 6908224,
+    "altSpellings": [
+      "RS",
+      "Srbija",
+      "Republic of Serbia",
+      "Република Србија",
+      "Republika Srbija"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/rs.svg",
+      "png": "https://flagcdn.com/w320/rs.png"
+    }
+  },
+  {
+    "name": "Seychelles",
+    "nativeName": "Seychelles",
+    "demonym": "Seychellois",
+    "population": 98462,
+    "altSpellings": [
+      "SC",
+      "Republic of Seychelles",
+      "Repiblik Sesel",
+      "République des Seychelles"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sc.svg",
+      "png": "https://flagcdn.com/w320/sc.png"
+    }
+  },
+  {
+    "name": "Sierra Leone",
+    "nativeName": "Sierra Leone",
+    "demonym": "Sierra Leonean",
+    "population": 7976985,
+    "altSpellings": [
+      "SL",
+      "Republic of Sierra Leone"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sl.svg",
+      "png": "https://flagcdn.com/w320/sl.png"
+    }
+  },
+  {
+    "name": "Singapore",
+    "nativeName": "Singapore",
+    "demonym": "Singaporean",
+    "population": 5685807,
+    "altSpellings": [
+      "SG",
+      "Singapura",
+      "Republik Singapura",
+      "新加坡共和国"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sg.svg",
+      "png": "https://flagcdn.com/w320/sg.png"
+    }
+  },
+  {
+    "name": "Sint Maarten (Dutch part)",
+    "nativeName": "Sint Maarten",
+    "demonym": "Dutch",
+    "population": 40812,
+    "altSpellings": [
+      "SX"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sx.svg",
+      "png": "https://flagcdn.com/w320/sx.png"
+    }
+  },
+  {
+    "name": "Slovakia",
+    "nativeName": "Slovensko",
+    "demonym": "Slovak",
+    "population": 5458827,
+    "altSpellings": [
+      "SK",
+      "Slovak Republic",
+      "Slovenská republika"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sk.svg",
+      "png": "https://flagcdn.com/w320/sk.png"
+    }
+  },
+  {
+    "name": "Slovenia",
+    "nativeName": "Slovenija",
+    "demonym": "Slovene",
+    "population": 2100126,
+    "altSpellings": [
+      "SI",
+      "Republic of Slovenia",
+      "Republika Slovenija"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/si.svg",
+      "png": "https://flagcdn.com/w320/si.png"
+    }
+  },
+  {
+    "name": "Solomon Islands",
+    "nativeName": "Solomon Islands",
+    "demonym": "Solomon Islander",
+    "population": 686878,
+    "altSpellings": [
+      "SB"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sb.svg",
+      "png": "https://flagcdn.com/w320/sb.png"
+    }
+  },
+  {
+    "name": "Somalia",
+    "nativeName": "Soomaaliya",
+    "demonym": "Somali",
+    "population": 15893219,
+    "altSpellings": [
+      "SO",
+      "aṣ-Ṣūmāl",
+      "Federal Republic of Somalia",
+      "Jamhuuriyadda Federaalka Soomaaliya",
+      "Jumhūriyyat aṣ-Ṣūmāl al-Fiderāliyya"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/so.svg",
+      "png": "https://flagcdn.com/w320/so.png"
+    }
+  },
+  {
+    "name": "South Africa",
+    "nativeName": "South Africa",
+    "demonym": "South African",
+    "population": 59308690,
+    "altSpellings": [
+      "ZA",
+      "RSA",
+      "Suid-Afrika",
+      "Republic of South Africa"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/za.svg",
+      "png": "https://flagcdn.com/w320/za.png"
+    }
+  },
+  {
+    "name": "South Georgia and the South Sandwich Islands",
+    "nativeName": "South Georgia",
+    "demonym": "South Georgia and the South Sandwich Islander",
+    "population": 30,
+    "altSpellings": [
+      "GS",
+      "South Georgia and the South Sandwich Islands"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gs.svg",
+      "png": "https://flagcdn.com/w320/gs.png"
+    }
+  },
+  {
+    "name": "Korea (Republic of)",
+    "nativeName": "대한민국",
+    "demonym": "South Korean",
+    "population": 51780579,
+    "altSpellings": [
+      "KR",
+      "Republic of Korea"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/kr.svg",
+      "png": "https://flagcdn.com/w320/kr.png"
+    }
+  },
+  {
+    "name": "Spain",
+    "nativeName": "España",
+    "demonym": "Spanish",
+    "population": 47351567,
+    "altSpellings": [
+      "ES",
+      "Kingdom of Spain",
+      "Reino de España"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/es.svg",
+      "png": "https://flagcdn.com/w320/es.png"
+    }
+  },
+  {
+    "name": "Sri Lanka",
+    "nativeName": "śrī laṃkāva",
+    "demonym": "Sri Lankan",
+    "population": 21919000,
+    "altSpellings": [
+      "LK",
+      "ilaṅkai",
+      "Democratic Socialist Republic of Sri Lanka"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/lk.svg",
+      "png": "https://flagcdn.com/w320/lk.png"
+    }
+  },
+  {
+    "name": "Sudan",
+    "nativeName": "السودان",
+    "demonym": "Sudanese",
+    "population": 43849269,
+    "altSpellings": [
+      "SD",
+      "Republic of the Sudan",
+      "Jumhūrīyat as-Sūdān"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sd.svg",
+      "png": "https://flagcdn.com/w320/sd.png"
+    }
+  },
+  {
+    "name": "South Sudan",
+    "nativeName": "South Sudan",
+    "demonym": "South Sudanese",
+    "population": 11193729,
+    "altSpellings": [
+      "SS"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ss.svg",
+      "png": "https://flagcdn.com/w320/ss.png"
+    }
+  },
+  {
+    "name": "Suriname",
+    "nativeName": "Suriname",
+    "demonym": "Surinamer",
+    "population": 586634,
+    "altSpellings": [
+      "SR",
+      "Sarnam",
+      "Sranangron",
+      "Republic of Suriname",
+      "Republiek Suriname"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sr.svg",
+      "png": "https://flagcdn.com/w320/sr.png"
+    }
+  },
+  {
+    "name": "Svalbard and Jan Mayen",
+    "nativeName": "Svalbard og Jan Mayen",
+    "demonym": "Norwegian",
+    "population": 2562,
+    "altSpellings": [
+      "SJ",
+      "Svalbard and Jan Mayen Islands"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sj.svg",
+      "png": "https://flagcdn.com/w320/sj.png"
+    }
+  },
+  {
+    "name": "Swaziland",
+    "nativeName": "Swaziland",
+    "demonym": "Swazi",
+    "population": 1160164,
+    "altSpellings": [
+      "SZ",
+      "weSwatini",
+      "Swatini",
+      "Ngwane",
+      "Kingdom of Swaziland",
+      "Umbuso waseSwatini"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sz.svg",
+      "png": "https://flagcdn.com/w320/sz.png"
+    }
+  },
+  {
+    "name": "Sweden",
+    "nativeName": "Sverige",
+    "demonym": "Swedish",
+    "population": 10353442,
+    "altSpellings": [
+      "SE",
+      "Kingdom of Sweden",
+      "Konungariket Sverige"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/se.svg",
+      "png": "https://flagcdn.com/w320/se.png"
+    }
+  },
+  {
+    "name": "Switzerland",
+    "nativeName": "Schweiz",
+    "demonym": "Swiss",
+    "population": 8636896,
+    "altSpellings": [
+      "CH",
+      "Swiss Confederation",
+      "Schweiz",
+      "Suisse",
+      "Svizzera",
+      "Svizra"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ch.svg",
+      "png": "https://flagcdn.com/w320/ch.png"
+    }
+  },
+  {
+    "name": "Syrian Arab Republic",
+    "nativeName": "سوريا",
+    "demonym": "Syrian",
+    "population": 17500657,
+    "altSpellings": [
+      "SY",
+      "Syrian Arab Republic",
+      "Al-Jumhūrīyah Al-ʻArabīyah As-Sūrīyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/sy.svg",
+      "png": "https://flagcdn.com/w320/sy.png"
+    }
+  },
+  {
+    "name": "Taiwan",
+    "nativeName": "臺灣",
+    "demonym": "Taiwanese",
+    "population": 23503349,
+    "altSpellings": [
+      "TW",
+      "Táiwān",
+      "Republic of China",
+      "中華民國",
+      "Zhōnghuá Mínguó"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tw.svg",
+      "png": "https://flagcdn.com/w320/tw.png"
+    }
+  },
+  {
+    "name": "Tajikistan",
+    "nativeName": "Тоҷикистон",
+    "demonym": "Tadzhik",
+    "population": 9537642,
+    "altSpellings": [
+      "TJ",
+      "Toçikiston",
+      "Republic of Tajikistan",
+      "Ҷумҳурии Тоҷикистон",
+      "Çumhuriyi Toçikiston"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tj.svg",
+      "png": "https://flagcdn.com/w320/tj.png"
+    }
+  },
+  {
+    "name": "Tanzania, United Republic of",
+    "nativeName": "Tanzania",
+    "demonym": "Tanzanian",
+    "population": 59734213,
+    "altSpellings": [
+      "TZ",
+      "United Republic of Tanzania",
+      "Jamhuri ya Muungano wa Tanzania"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tz.svg",
+      "png": "https://flagcdn.com/w320/tz.png"
+    }
+  },
+  {
+    "name": "Thailand",
+    "nativeName": "ประเทศไทย",
+    "demonym": "Thai",
+    "population": 69799978,
+    "altSpellings": [
+      "TH",
+      "Prathet",
+      "Thai",
+      "Kingdom of Thailand",
+      "ราชอาณาจักรไทย",
+      "Ratcha Anachak Thai"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/th.svg",
+      "png": "https://flagcdn.com/w320/th.png"
+    }
+  },
+  {
+    "name": "Timor-Leste",
+    "nativeName": "Timor-Leste",
+    "demonym": "East Timorese",
+    "population": 1318442,
+    "altSpellings": [
+      "TL",
+      "East Timor",
+      "Democratic Republic of Timor-Leste",
+      "República Democrática de Timor-Leste",
+      "Repúblika Demokrátika Timór-Leste"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tl.svg",
+      "png": "https://flagcdn.com/w320/tl.png"
+    }
+  },
+  {
+    "name": "Togo",
+    "nativeName": "Togo",
+    "demonym": "Togolese",
+    "population": 8278737,
+    "altSpellings": [
+      "TG",
+      "Togolese",
+      "Togolese Republic",
+      "République Togolaise"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tg.svg",
+      "png": "https://flagcdn.com/w320/tg.png"
+    }
+  },
+  {
+    "name": "Tokelau",
+    "nativeName": "Tokelau",
+    "demonym": "Tokelauan",
+    "population": 1411,
+    "altSpellings": [
+      "TK"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tk.svg",
+      "png": "https://flagcdn.com/w320/tk.png"
+    }
+  },
+  {
+    "name": "Tonga",
+    "nativeName": "Tonga",
+    "demonym": "Tongan",
+    "population": 105697,
+    "altSpellings": [
+      "TO"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/to.svg",
+      "png": "https://flagcdn.com/w320/to.png"
+    }
+  },
+  {
+    "name": "Trinidad and Tobago",
+    "nativeName": "Trinidad and Tobago",
+    "demonym": "Trinidadian",
+    "population": 1399491,
+    "altSpellings": [
+      "TT",
+      "Republic of Trinidad and Tobago"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tt.svg",
+      "png": "https://flagcdn.com/w320/tt.png"
+    }
+  },
+  {
+    "name": "Tunisia",
+    "nativeName": "تونس",
+    "demonym": "Tunisian",
+    "population": 11818618,
+    "altSpellings": [
+      "TN",
+      "Republic of Tunisia",
+      "al-Jumhūriyyah at-Tūnisiyyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tn.svg",
+      "png": "https://flagcdn.com/w320/tn.png"
+    }
+  },
+  {
+    "name": "Turkey",
+    "nativeName": "Türkiye",
+    "demonym": "Turkish",
+    "population": 84339067,
+    "altSpellings": [
+      "TR",
+      "Turkiye",
+      "Republic of Turkey",
+      "Türkiye Cumhuriyeti"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tr.svg",
+      "png": "https://flagcdn.com/w320/tr.png"
+    }
+  },
+  {
+    "name": "Turkmenistan",
+    "nativeName": "Türkmenistan",
+    "demonym": "Turkmen",
+    "population": 6031187,
+    "altSpellings": [
+      "TM"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tm.svg",
+      "png": "https://flagcdn.com/w320/tm.png"
+    }
+  },
+  {
+    "name": "Turks and Caicos Islands",
+    "nativeName": "Turks and Caicos Islands",
+    "demonym": "Turks and Caicos Islander",
+    "population": 38718,
+    "altSpellings": [
+      "TC"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tc.svg",
+      "png": "https://flagcdn.com/w320/tc.png"
+    }
+  },
+  {
+    "name": "Tuvalu",
+    "nativeName": "Tuvalu",
+    "demonym": "Tuvaluan",
+    "population": 11792,
+    "altSpellings": [
+      "TV"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/tv.svg",
+      "png": "https://flagcdn.com/w320/tv.png"
+    }
+  },
+  {
+    "name": "Uganda",
+    "nativeName": "Uganda",
+    "demonym": "Ugandan",
+    "population": 45741000,
+    "altSpellings": [
+      "UG",
+      "Republic of Uganda",
+      "Jamhuri ya Uganda"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ug.svg",
+      "png": "https://flagcdn.com/w320/ug.png"
+    }
+  },
+  {
+    "name": "Ukraine",
+    "nativeName": "Україна",
+    "demonym": "Ukrainian",
+    "population": 44134693,
+    "altSpellings": [
+      "UA",
+      "Ukrayina"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ua.svg",
+      "png": "https://flagcdn.com/w320/ua.png"
+    }
+  },
+  {
+    "name": "United Arab Emirates",
+    "nativeName": "دولة الإمارات العربية المتحدة",
+    "demonym": "Emirati",
+    "population": 9890400,
+    "altSpellings": [
+      "AE",
+      "UAE"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ae.svg",
+      "png": "https://flagcdn.com/w320/ae.png"
+    }
+  },
+  {
+    "name": "United Kingdom of Great Britain and Northern Ireland",
+    "nativeName": "United Kingdom",
+    "demonym": "British",
+    "population": 67215293,
+    "altSpellings": [
+      "GB",
+      "UK",
+      "Great Britain"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/gb.svg",
+      "png": "https://flagcdn.com/w320/gb.png"
+    }
+  },
+  {
+    "name": "United States of America",
+    "nativeName": "United States",
+    "demonym": "American",
+    "population": 329484123,
+    "altSpellings": [
+      "US",
+      "USA",
+      "United States of America"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/us.svg",
+      "png": "https://flagcdn.com/w320/us.png"
+    }
+  },
+  {
+    "name": "Uruguay",
+    "nativeName": "Uruguay",
+    "demonym": "Uruguayan",
+    "population": 3473727,
+    "altSpellings": [
+      "UY",
+      "Oriental Republic of Uruguay",
+      "República Oriental del Uruguay"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/uy.svg",
+      "png": "https://flagcdn.com/w320/uy.png"
+    }
+  },
+  {
+    "name": "Uzbekistan",
+    "nativeName": "O‘zbekiston",
+    "demonym": "Uzbekistani",
+    "population": 34232050,
+    "altSpellings": [
+      "UZ",
+      "Republic of Uzbekistan",
+      "O‘zbekiston Respublikasi",
+      "Ўзбекистон Республикаси"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/uz.svg",
+      "png": "https://flagcdn.com/w320/uz.png"
+    }
+  },
+  {
+    "name": "Vanuatu",
+    "nativeName": "Vanuatu",
+    "demonym": "Ni-Vanuatu",
+    "population": 307150,
+    "altSpellings": [
+      "VU",
+      "Republic of Vanuatu",
+      "Ripablik blong Vanuatu",
+      "République de Vanuatu"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/vu.svg",
+      "png": "https://flagcdn.com/w320/vu.png"
+    }
+  },
+  {
+    "name": "Venezuela (Bolivarian Republic of)",
+    "nativeName": "Venezuela",
+    "demonym": "Venezuelan",
+    "population": 28435943,
+    "altSpellings": [
+      "VE",
+      "Bolivarian Republic of Venezuela",
+      "República Bolivariana de Venezuela"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ve.svg",
+      "png": "https://flagcdn.com/w320/ve.png"
+    }
+  },
+  {
+    "name": "Vietnam",
+    "nativeName": "Việt Nam",
+    "demonym": "Vietnamese",
+    "population": 97338583,
+    "altSpellings": [
+      "VN",
+      "Socialist Republic of Vietnam",
+      "Cộng hòa Xã hội chủ nghĩa Việt Nam"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/vn.svg",
+      "png": "https://flagcdn.com/w320/vn.png"
+    }
+  },
+  {
+    "name": "Wallis and Futuna",
+    "nativeName": "Wallis et Futuna",
+    "demonym": "Wallis and Futuna Islander",
+    "population": 11750,
+    "altSpellings": [
+      "WF",
+      "Territory of the Wallis and Futuna Islands",
+      "Territoire des îles Wallis et Futuna"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/wf.svg",
+      "png": "https://flagcdn.com/w320/wf.png"
+    }
+  },
+  {
+    "name": "Western Sahara",
+    "nativeName": "الصحراء الغربية",
+    "demonym": "Sahrawi",
+    "population": 510713,
+    "altSpellings": [
+      "EH",
+      "Taneẓroft Tutrimt"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/eh.svg",
+      "png": "https://flagcdn.com/w320/eh.png"
+    }
+  },
+  {
+    "name": "Yemen",
+    "nativeName": "اليَمَن",
+    "demonym": "Yemeni",
+    "population": 29825968,
+    "altSpellings": [
+      "YE",
+      "Yemeni Republic",
+      "al-Jumhūriyyah al-Yamaniyyah"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/ye.svg",
+      "png": "https://flagcdn.com/w320/ye.png"
+    }
+  },
+  {
+    "name": "Zambia",
+    "nativeName": "Zambia",
+    "demonym": "Zambian",
+    "population": 18383956,
+    "altSpellings": [
+      "ZM",
+      "Republic of Zambia"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/zm.svg",
+      "png": "https://flagcdn.com/w320/zm.png"
+    }
+  },
+  {
+    "name": "Zimbabwe",
+    "nativeName": "Zimbabwe",
+    "demonym": "Zimbabwean",
+    "population": 14862927,
+    "altSpellings": [
+      "ZW",
+      "Republic of Zimbabwe"
+    ],
+    "flags": {
+      "svg": "https://flagcdn.com/zw.svg",
+      "png": "https://flagcdn.com/w320/zw.png"
+    }
+  }
+] as Country[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import LastResult from './cards/last-result';
 import { BaseCard } from './cards/base-card';
 import Countdown from './cards/countdown';
 import Results from './cards/results';
-import RestCountryClient from './api/restcountry-client';
 import { CARD_EDITOR_NAME, CARD_NAME } from './consts';
 
 console.info(
@@ -49,8 +48,6 @@ export default class FormulaOneCard extends LitElement {
 
     constructor() {
         super();
-        
-        this.setCountryCache();
     }
 
     private _cardValues?: Map<string, unknown>;
@@ -66,13 +63,6 @@ export default class FormulaOneCard extends LitElement {
         checkConfig(config);
 
         this.config = { ...config };
-    }
-
-    setCountryCache() {
-        new RestCountryClient().GetAll().catch(() => { 
-            this.warning = 'Country API is down, so flags are not available at the moment!'; 
-            this.update(this._cardValues);
-        });
     }
 
     protected shouldUpdate(changedProps: PropertyValues): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,10 +47,13 @@ export const getCountryFlagByNationality = (card: BaseCard, nationality: string)
     }
     
     const country = countries.filter(x => x.demonym == nationality);
+    if(country.length === 0) {
+        return '';
+    }
     if(country.length > 1)
     {
         return card.imageClient.GetImage(country.sort((a, b) => (a.population > b.population) ? -1 : 1)[0].flags.png);
-    }    
+    }
 
     return card.imageClient.GetImage(country[0].flags.png);
 }
@@ -60,6 +63,10 @@ export const getCountryFlagByName = (card: BaseCard, countryName: string) => {
     
     const country = countries.filter(x => x.name == countryName || x.nativeName == countryName ||
         x.altSpellings?.includes(countryName))[0];
+
+    if(!country) {
+        return '';
+    }
 
     return card.imageClient.GetImage(country.flags.png);
 }

--- a/tests/api/restcountry-client.test.ts
+++ b/tests/api/restcountry-client.test.ts
@@ -1,50 +1,25 @@
-// Mocks
-import fetchMock from "jest-fetch-mock";
-import LocalStorageMock from "../testdata/localStorageMock";
-
 // Models
 import RestCountryClient from "../../src/api/restcountry-client";
-import { LocalStorageItem } from "../../src/types/formulaone-card-types";
-
-// Importing test data
-import * as countryData from '../testdata/countries.json'
+import { countries } from "../../src/data/countries";
 
 describe('Testing restcountry client file', () => {
 
-    const client = new RestCountryClient();    
-    const localStorageMock = new LocalStorageMock();
+    const client = new RestCountryClient();
 
-    Object.defineProperty(window, 'localStorage', { value: localStorageMock });
-
-    test('Calling GetCountriesFromLocalStorage should return correct data', () => {   
-         // Arrange
-        localStorageMock.clear();     
-        localStorageMock.setItem('all', JSON.stringify({ data: JSON.stringify(countryData), created: new Date() } as LocalStorageItem));
-
-        // Act
-        const countries = client.GetCountriesFromLocalStorage();
-
-        // Assert
-        expect(JSON.stringify(countries)).toMatch(JSON.stringify(countryData));
+    test('GetAll should return static country data', () => {
+        const result = client.GetAll();
+        expect(result).toBe(countries);
+        expect(result.length).toBeGreaterThan(0);
     }),
-    test('Calling GetCountriesFromLocalStorage should return correct data without localstorage', () => {   
-        // Arrange
-        localStorageMock.clear();     
-
-        // Act
-        const countries = client.GetCountriesFromLocalStorage();
-
-        // Assert
-        expect(JSON.stringify(countries)).toMatch(JSON.stringify([]));
+    test('GetCountriesFromLocalStorage should return static country data', () => {
+        const result = client.GetCountriesFromLocalStorage();
+        expect(result).toBe(countries);
     }),
-    test('Calling GetAll should return correct data', async () => { 
-        // Arrange
-        fetchMock.mockResponseOnce(JSON.stringify(countryData));
-
-        // Act
-        const result = await client.GetAll();
-
-        // Assert
-        expect(JSON.stringify(result)).toMatch(JSON.stringify(countryData));
+    test('Country data should contain Italy with correct demonym', () => {
+        const result = client.GetAll();
+        const italy = result.filter(c => c.name === 'Italy');
+        expect(italy.length).toBe(1);
+        expect(italy[0].demonym).toBe('Italian');
+        expect(italy[0].flags.png).toContain('flagcdn.com');
     })
 })


### PR DESCRIPTION
## Summary

Fixes #490, fixes #489

The `restcountries.com` v2 API has been deprecated — it no longer returns CORS headers, so browsers block the request entirely. This causes:
- "Country API is down, so flags are not available at the moment!" warning on every card
- `TypeError` crashes in `getCountryFlagByName` / `getCountryFlagByNationality` when country data is empty

### Changes

- **Embed static country data** (`src/data/countries.ts`) — 250 countries with only the fields the card uses (`name`, `nativeName`, `demonym`, `population`, `altSpellings`, `flags`). Flag image URLs point to `flagcdn.com` (same CDN restcountries v2 used).
- **Simplify `RestCountryClient`** — `GetAll()` and `GetCountriesFromLocalStorage()` now return the static data directly. No API calls, no localStorage caching needed.
- **Remove `setCountryCache()`** from the constructor and the warning logic — no longer needed since data is bundled.
- **Add null-safety** to `getCountryFlagByNationality` and `getCountryFlagByName` — return empty string instead of crashing when a country is not found.
- **Update tests** to match the new synchronous data source.

### Trade-offs

- Bundle size increases by ~85KB (static country data). Countries rarely change, so staleness is minimal.
- If a country name/demonym changes, the data file needs a manual update. This is significantly more reliable than depending on a third-party API that has already been deprecated twice.

## Test plan

- [x] `restcountry-client.test.ts` — all 3 tests pass
- [x] `getCountryFlagUrl.test.ts` — all 2 tests pass  
- [x] Full test suite: 81 passed (vs 80 on `main`), 26 failed (vs 27 on `main`) — pre-existing failures from formula1.com image URL changes, not related to this PR